### PR TITLE
CI builds & looser device-name check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
           body: This is an automated release for ${{ github.ref }}.
         env:
           GITHUB_TOKEN: ${{ github.token }}
+  
   build-windows:
     runs-on: windows-latest
     needs: create_release
@@ -53,6 +54,7 @@ jobs:
           asset_path: rm8-windows.zip
           asset_name: rm8-windows.zip
           asset_content_type: application/zip
+  
   build-mac:
     runs-on: macos-latest
     needs: create_release
@@ -71,6 +73,7 @@ jobs:
           asset_path: rm8-mac-x86_64.zip
           asset_name: rm8-mac-x86_64.zip
           asset_content_type: application/zip
+  
   build-linux:
     needs: create_release
     runs-on: ubuntu-latest
@@ -115,7 +118,7 @@ jobs:
         with:
           arch: aarch64
       - name: Zip aarch64
-        run: cp target/aarch64-unknown-linux-gnueabihf/release/rm8 . && zip -r rm8-linux-aarch64.zip rm8 *.json README.md
+        run: cp target/aarch64-unknown-linux-gnu/release/rm8 . && zip -r rm8-linux-aarch64.zip rm8 *.json README.md
       - name: upload rm8-linux-aarch64 artifact
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,113 @@
 name: Build & Release
 
 on:
-  push
+  push:
+    tags:
+      - 'v*'
 
 jobs:
-  build:
+  create_release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: ["arm-unknown-linux-gnueabi", "aarch64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-gnu"]
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: create_release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          draft: false
+          prerelease: false
+          release_name: Automated Release ${{ github.ref }}
+          tag_name: ${{ github.ref }}
+          body: This is an automated release for ${{ github.ref }}.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+  build-linux:
+    runs-on: ubuntu-latest
+    needs: create_release
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build x86_64-unknown-linux-gnu
+        run: sudo scripts/build_linux.sh rm8-linux-x86_64.zip
+      - name: upload rm8-linux-x86_64 artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-linux-x86_64.zip
+          asset_name: rm8-linux-x86_64.zip
+          asset_content_type: application/zip
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Build aarch64-unknown-linux-gnu
+        run: docker run --platform linux/arm64 --rm -v "${PWD}:/work" -w /work rust /work/scripts/build_linux.sh rm8-linux-aarch64.zip
+      - name: upload rm8-linux-aarch64 artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-linux-aarch64.zip
+          asset_name: rm8-linux-aarch64.zip
+          asset_content_type: application/zip
+      - name: Build arm-unknown-linux-gnu
+        run: docker run --platform linux/arm --rm -v "${PWD}:/work" -w /work rust /work/scripts/build_linux.sh rm8-linux-arm32.zip
+      - name: upload rm8-linux-arm32 artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-linux-arm32.zip
+          asset_name: rm8-linux-arm32.zip
+          asset_content_type: application/zip
+  build-mac:
+    runs-on: macos-latest
+    needs: create_release
     steps:
       - uses: actions/checkout@v3
       - name: Install Build Deps
-        run: >
-          sudo apt install -y libsdl2-dev
-          cargo install cross --git https://github.com/cross-rs/cross
-      - name: Build
-        run: cross build --target ${{ matrix.version }} --release
+        run: brew install sdl2
+      - name: Build x86_64-apple-darwin
+        run: cargo build --release && cp target/release/rm8 . && zip -r rm8-mac.zip rm8 *.json README.md
+      - name: upload x86_64-apple-darwin artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-mac.zip
+          asset_name: rm8-mac.zip
+          asset_content_type: application/zip
+  build-windows:
+    runs-on: windows-latest
+    needs: create_release
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download SDL
+        uses: suisei-cn/actions-download-file@v1.3.0
+        with:
+          url: "https://github.com/libsdl-org/SDL/releases/download/release-2.26.1/SDL2-devel-2.26.1-VC.zip"
+          target: .
+      - name: Unzip SDL
+        run: unzip -a SDL2-devel-2.26.1-VC.zip && copy SDL2-2.26.1\lib\x64\SDL2.dll .
+      - name: Build x86_64-pc-windows-gnu
+        run: cargo build --release && mkdir target/out && copy target/release/rm8.exe target/out && copy SDL2.dll target/out && copy *.json target/out && copy README.md target/out
+        env:
+          LIB: SDL2-2.26.1\lib\x64\
+      - name: Archive Release
+        uses: thedoctor0/zip-release@main
+        with:
+          type: zip
+          filename: ../../rm8-windows.zip
+          directory: target/out
+      - name: upload windows artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-windows.zip
+          asset_name: rm8-windows.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Build & Release
+
+on:
+  push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["arm-unknown-linux-gnueabi", "aarch64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-gnu"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Build Deps
+        run: >
+          sudo apt install -y libsdl2-dev
+          cargo install cross --git https://github.com/cross-rs/cross
+      - name: Build
+        run: cross build --target ${{ matrix.version }} --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         run: cargo build --release && mkdir target/out && copy target/release/rm8.exe target/out && copy SDL2.dll target/out && copy *.json target/out && copy README.md target/out
         env:
           LIB: SDL2-2.26.1\lib\x64\
+          CARGO_CFG_TARGET_FEATURE: crt-static
       - name: Archive Release
         uses: thedoctor0/zip-release@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,64 +22,6 @@ jobs:
           body: This is an automated release for ${{ github.ref }}.
         env:
           GITHUB_TOKEN: ${{ github.token }}
-  build-linux:
-    runs-on: ubuntu-latest
-    needs: create_release
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build x86_64-unknown-linux-gnu
-        run: sudo scripts/build_linux.sh rm8-linux-x86_64.zip
-      - name: upload rm8-linux-x86_64 artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: rm8-linux-x86_64.zip
-          asset_name: rm8-linux-x86_64.zip
-          asset_content_type: application/zip
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Build aarch64-unknown-linux-gnu
-        run: docker run --platform linux/arm64 --rm -v "${PWD}:/work" -w /work rust /work/scripts/build_linux.sh rm8-linux-aarch64.zip
-      - name: upload rm8-linux-aarch64 artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: rm8-linux-aarch64.zip
-          asset_name: rm8-linux-aarch64.zip
-          asset_content_type: application/zip
-      - name: Build arm-unknown-linux-gnu
-        run: docker run --platform linux/arm --rm -v "${PWD}:/work" -w /work rust /work/scripts/build_linux.sh rm8-linux-arm32.zip
-      - name: upload rm8-linux-arm32 artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: rm8-linux-arm32.zip
-          asset_name: rm8-linux-arm32.zip
-          asset_content_type: application/zip
-  build-mac:
-    runs-on: macos-latest
-    needs: create_release
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Build Deps
-        run: brew install sdl2
-      - name: Build x86_64-apple-darwin
-        run: cargo build --release && cp target/release/rm8 . && zip -r rm8-mac.zip rm8 *.json README.md
-      - name: upload x86_64-apple-darwin artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: rm8-mac.zip
-          asset_name: rm8-mac.zip
-          asset_content_type: application/zip
   build-windows:
     runs-on: windows-latest
     needs: create_release
@@ -110,4 +52,76 @@ jobs:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: rm8-windows.zip
           asset_name: rm8-windows.zip
+          asset_content_type: application/zip
+  build-mac:
+    runs-on: macos-latest
+    needs: create_release
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Build Deps
+        run: brew install sdl2
+      - name: Build x86_64-apple-darwin
+        run: cargo build --release && cp target/release/rm8 . && zip -r rm8-mac-x86_64.zip rm8 *.json README.md
+      - name: upload x86_64-apple-darwin artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-mac-x86_64.zip
+          asset_name: rm8-mac-x86_64.zip
+          asset_content_type: application/zip
+  build-linux:
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      
+      - name: Build M8 x86_64
+        uses: konsumer/action-build-rm8@v1
+        with:
+          arch: x86_64
+      - name: Zip x86_64
+        run: cp target/x86_64-unknown-linux-gnu/release/rm8 . && zip -r rm8-linux-x86_64.zip rm8 *.json README.md
+      - name: upload rm8-linux-x86_64 artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-linux-x86_64.zip
+          asset_name: rm8-linux-x86_64.zip
+          asset_content_type: application/zip
+
+      - name: Build M8 armv7
+        uses: konsumer/action-build-rm8@v1
+        with:
+          arch: armv7
+      - name: Zip armv7
+        run: cp target/armv7-unknown-linux-gnueabihf/release/rm8 . && zip -r rm8-linux-armv7.zip rm8 *.json README.md
+      - name: upload rm8-linux-arm7 artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-linux-armv7.zip
+          asset_name: rm8-linux-armv7.zip
+          asset_content_type: application/zip
+
+      - name: Build M8 aarch64
+        uses: konsumer/action-build-rm8@v1
+        with:
+          arch: aarch64
+      - name: Zip aarch64
+        run: cp target/aarch64-unknown-linux-gnueabihf/release/rm8 . && zip -r rm8-linux-aarch64.zip rm8 *.json README.md
+      - name: upload rm8-linux-aarch64 artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: rm8-linux-aarch64.zip
+          asset_name: rm8-linux-aarch64.zip
           asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 rm8-*-archlinux*
 rm8-*-win64*
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ serde = "1.0.131"
 serde_derive = "1.0.131"
 serde_json = "1.0.72"
 serialport = "4.0.1"
+
+[features]
+# build my own bundled copy of SDL2 and static-link it
+static-link = ["sdl2/static-link", "sdl2/bundled"]

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -16,6 +16,7 @@ If the latency is too high, try adding `-smp 512` param.
 
 ## Linux
 
+- Get latest [release](https://github.com/konsumer/rm8/releases) for your arch (aarch64/x86_64)
 - Install SDL2 (on ubuntu/debian/etc: `apt install libsdl2-2.0-0`)
 - Make sure you have read/write permissions on the device (`./rm8 -list` with it plugged in to see devices) Generally just adding yourself to the group that owns the device will do it.
 

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -37,6 +37,8 @@ cd "${DIR}/M8"
 ./rm8
 ```
 
+Input is mapped so SELECT exits, and START is CONFIG. Dpad and analog works, and face-buttons are for editing (similar to real M8.)
+
 
 ## Steamdeck
 

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -1,5 +1,18 @@
 Here are some hints to get rm8 running on various devices.
 
+## Mac
+
+- [Install Homebrew](https://brew.sh/)
+- Open a terminal and run `brew install sdl2`
+- Get latest [release](https://github.com/konsumer/rm8/releases) for your mac (M1/x86_64)
+- open it and go to settings/privacy and ok it running an unsigned app
+
+## Linux
+
+- Install SDL2 (on ubuntu/debian/etc: `apt install libsdl2-2.0-0`)
+- Make sure you have read/write permissions on the device (`./rm8 -list` with it plugged in to see devices) Generally just adding yourself to the group that owns the device will do it.
+
+
 ## Anbernic RG353P
 
 ![RG353P](https://user-images.githubusercontent.com/83857/209609257-1da08aca-d8fa-48cc-98ed-e3e54d89136e.jpeg)

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -12,7 +12,7 @@ If the latency is too high, try adding `-smp 512` param.
 - Open a terminal and run `brew install sdl2`
 - Get latest [release](https://github.com/konsumer/rm8/releases) for your mac (M1/x86_64)
 - open it and go to settings/privacy and ok it running an unsigned app
-- Currently, sound is not working on Mac, but you can open "Quicktime Player" and choose "New Audio Recording" in "File" menu, then select "M8" and turn up the monitor slider. I'd like to figure out why it doesn't work like other platforms, but for now this will work (similar to m8c)
+- If sound is not working, then the loopback is failing (whcih sometimes happens on mac, for some reason) but you can open "Quicktime Player" and choose "New Audio Recording" in "File" menu, then select "M8" and turn up the monitor slider. I'd like to figure out why it doesn't work like other platforms, but for now this will work (similar to m8c)
 
 ## Linux
 

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -65,10 +65,9 @@ Input is mapped so SELECT exits, and START is CONFIG. Dpad and analog works, and
 
 ![steamdeck](https://user-images.githubusercontent.com/83857/209611069-7cf42ce3-7690-42ba-8d52-d511f68faf95.jpeg)
 
-- [setup ssh](https://shendrick.net/Gaming/2022/05/30/sshonsteamdeck.html)
 - Copy URL for [latest rm8-linux-x86_64.zip release](https://github.com/konsumer/rm8/releases)
 
-On your computer `ssh deck@IP_ADDRESS`, or you can use desktop-mode terminal:
+On your computer `ssh deck@IP_ADDRESS` ([setup ssh](https://shendrick.net/Gaming/2022/05/30/sshonsteamdeck.html)), or you can use desktop-mode terminal:
 
 ```
 cd ~
@@ -81,5 +80,5 @@ unzip r.zip
 rm r.zip
 ```
 
-- in Desktop-mode, open steam add non-steam game for `/home/deck/M8/rm8` and set working-dir to `/home/deck/M8`
+- in Desktop-mode, open steam, add non-steam game for `/home/deck/M8/rm8` and set working-dir to `/home/deck/M8`
 - In controller-configuration, choose the `rm8` community-profile I (konsumer) made.

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -1,5 +1,9 @@
 Here are some hints to get rm8 running on various devices.
 
+## Windows
+
+It should work, as it is, but if you get an error about `VCRUNTIME140` install [this](https://www.microsoft.com/en-us/download/details.aspx?id=52685).
+
 ## Mac
 
 - [Install Homebrew](https://brew.sh/)

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -1,0 +1,60 @@
+Here are some hints to 
+
+## Anbernic RG353P
+
+![RG353P](https://user-images.githubusercontent.com/83857/209609257-1da08aca-d8fa-48cc-98ed-e3e54d89136e.jpeg)
+
+- Install [JELOS](https://github.com/JustEnoughLinuxOS/distribution)
+- In network-settings enable wifi & ssh
+- Copy URL for [latest aarch64 release zip](https://github.com/konsumer/rm8/releases)
+
+On your computer `ssh root@IP_ADDRESS` (password is in settings, chnages on every boot):
+
+```
+cd ~/roms/ports
+mkdir M8
+cd M8
+
+# ZIP_URL come from releases: x86-64
+wget ZIP_URL -o r.zip
+unzip r.zip
+rm r.zip
+
+# make it look like script below
+nano ../M8.sh
+```
+
+*~/roms/ports/M8.sh*
+```sh
+#!/bin/bash
+
+DIR="$( dirname "${BASH_SOURCE[0]}"; )"
+DIR="$( realpath "$DIR" )"
+
+cd "${DIR}/M8"
+./rm8
+```
+
+
+## Steamdeck
+
+![steamdeck](https://user-images.githubusercontent.com/83857/209611069-7cf42ce3-7690-42ba-8d52-d511f68faf95.jpeg)
+
+- [setup ssh](https://shendrick.net/Gaming/2022/05/30/sshonsteamdeck.html)
+- Copy URL for [latest x86-64 release zip](https://github.com/konsumer/rm8/releases)
+
+On your computer `ssh deck@IP_ADDRESS`, or you can use desktop-mode terminal:
+
+```
+cd ~
+mkdir M8
+cd M8
+
+# ZIP_URL come from releases: x86-64
+wget ZIP_URL -o r.zip
+unzip r.zip
+rm r.zip
+```
+
+- in Desktop-mode, open steam add non-steam game for `/home/deck/M8/rm8` and set working-dir to `/home/deck/M8`
+- In controller-configuration (under steam-button menu when it's running) choose the `rm8` community-profile I (konsumer) made.

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -1,4 +1,4 @@
-Here are some hints to 
+Here are some hints to get rm8 running on various devices.
 
 ## Anbernic RG353P
 

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -16,7 +16,7 @@ mkdir M8
 cd M8
 
 # ZIP_URL come from releases: x86-64
-wget ZIP_URL -o r.zip
+wget ZIP_URL -O r.zip
 unzip r.zip
 rm r.zip
 
@@ -55,7 +55,7 @@ mkdir M8
 cd M8
 
 # ZIP_URL come from releases: x86-64
-wget ZIP_URL -o r.zip
+wget ZIP_URL -O r.zip
 unzip r.zip
 rm r.zip
 ```

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -10,7 +10,7 @@ It should work, as it is, but if you get an error about `VCRUNTIME140` install [
 - Open a terminal and run `brew install sdl2`
 - Get latest [release](https://github.com/konsumer/rm8/releases) for your mac (M1/x86_64)
 - open it and go to settings/privacy and ok it running an unsigned app
-- Currently, sound is not working on Mac, but you can open "Quicktime Player" and choose "New Audio Recording" in "File" menu, then select "M8" and turn up the monitor slider. I'd liek to figure out why it doesn;t work liek other platforms, but for now this will work (similar to m8c)
+- Currently, sound is not working on Mac, but you can open "Quicktime Player" and choose "New Audio Recording" in "File" menu, then select "M8" and turn up the monitor slider. I'd like to figure out why it doesn't work like other platforms, but for now this will work (similar to m8c)
 
 ## Linux
 

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -85,3 +85,4 @@ sudo usermod -G uucp deck
 
 - in Desktop-mode, open steam, add non-steam game for `/home/deck/M8/rm8` and set working-dir to `/home/deck/M8`
 - In controller-configuration, choose the `rm8` community-profile I (konsumer) made.
+- Reboot

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -6,7 +6,7 @@ Here are some hints to get rm8 running on various devices.
 
 - Install [JELOS](https://github.com/JustEnoughLinuxOS/distribution)
 - In network-settings enable wifi & ssh
-- Copy URL for [latest aarch64 release zip](https://github.com/konsumer/rm8/releases)
+- Copy URL for [latest rm8-linux-aarch64.zip release](https://github.com/konsumer/rm8/releases)
 
 On your computer `ssh root@IP_ADDRESS` (password is in settings, chnages on every boot):
 
@@ -45,7 +45,7 @@ Input is mapped so SELECT exits, and START is CONFIG. Dpad and analog works, and
 ![steamdeck](https://user-images.githubusercontent.com/83857/209611069-7cf42ce3-7690-42ba-8d52-d511f68faf95.jpeg)
 
 - [setup ssh](https://shendrick.net/Gaming/2022/05/30/sshonsteamdeck.html)
-- Copy URL for [latest x86-64 release zip](https://github.com/konsumer/rm8/releases)
+- Copy URL for [latest rm8-linux-x86_64.zip release](https://github.com/konsumer/rm8/releases)
 
 On your computer `ssh deck@IP_ADDRESS`, or you can use desktop-mode terminal:
 

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -78,6 +78,9 @@ cd M8
 wget ZIP_URL -O r.zip
 unzip r.zip
 rm r.zip
+
+# add main user to group that owns M8
+sudo usermod -G uucp deck
 ```
 
 - in Desktop-mode, open steam, add non-steam game for `/home/deck/M8/rm8` and set working-dir to `/home/deck/M8`

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -20,6 +20,8 @@ wget ZIP_URL -o r.zip
 unzip r.zip
 rm r.zip
 
+cp rm8-RG353P.json rm8.json
+
 # make it look like script below
 nano ../M8.sh
 ```

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -10,6 +10,7 @@ It should work, as it is, but if you get an error about `VCRUNTIME140` install [
 - Open a terminal and run `brew install sdl2`
 - Get latest [release](https://github.com/konsumer/rm8/releases) for your mac (M1/x86_64)
 - open it and go to settings/privacy and ok it running an unsigned app
+- Currently, sound is not working on Mac, but you can open "Quicktime Player" and choose "New Audio Recording" in "File" menu, then select "M8" and turn up the monitor slider. I'd liek to figure out why it doesn;t work liek other platforms, but for now this will work (similar to m8c)
 
 ## Linux
 

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -8,7 +8,7 @@ If the latency is too high, try adding `-smp 512` param.
 
 ## Mac
 
-- [Install Homebrew](https://brew.sh/)
+- [Install Homebrew](https://brew.sh/), a great general tool for managing libraries and stuff
 - Open a terminal and run `brew install sdl2`
 - Get latest [release](https://github.com/konsumer/rm8/releases) for your mac (M1/x86_64)
 - open it and go to settings/privacy and ok it running an unsigned app

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -15,7 +15,7 @@ cd ~/roms/ports
 mkdir M8
 cd M8
 
-# ZIP_URL come from releases: x86-64
+# ZIP_URL come from releases: aarch64
 wget ZIP_URL -O r.zip
 unzip r.zip
 rm r.zip

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -4,6 +4,8 @@ Here are some hints to get rm8 running on various devices.
 
 It should work, as it is, but if you get an error about `VCRUNTIME140` install [this](https://www.microsoft.com/en-us/download/details.aspx?id=52685).
 
+If the latency is too high, try adding `-smp 512` param.
+
 ## Mac
 
 - [Install Homebrew](https://brew.sh/)

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -61,4 +61,4 @@ rm r.zip
 ```
 
 - in Desktop-mode, open steam add non-steam game for `/home/deck/M8/rm8` and set working-dir to `/home/deck/M8`
-- In controller-configuration (under steam-button menu when it's running) choose the `rm8` community-profile I (konsumer) made.
+- In controller-configuration, choose the `rm8` community-profile I (konsumer) made.

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -80,7 +80,7 @@ unzip r.zip
 rm r.zip
 
 # add main user to group that owns M8
-sudo usermod -G uucp deck
+sudo usermod -a -G uucp deck
 ```
 
 - in Desktop-mode, open steam, add non-steam game for `/home/deck/M8/rm8` and set working-dir to `/home/deck/M8`

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -21,9 +21,11 @@ If the latency is too high, try adding `-smp 512` param.
 - Make sure you have read/write permissions on the device (`./rm8 -list` with it plugged in to see devices) Generally just adding yourself to the group that owns the device will do it.
 
 
-## Anbernic RG353P
+## Anbernic RG353P / RG353V
 
-![RG353P](https://user-images.githubusercontent.com/83857/209609257-1da08aca-d8fa-48cc-98ed-e3e54d89136e.jpeg)
+| RG353P      | RG353V |
+| ----------- | ----------- |
+| <img src="https://user-images.githubusercontent.com/83857/209609257-1da08aca-d8fa-48cc-98ed-e3e54d89136e.jpeg " width=450px>     |  <img src="https://user-images.githubusercontent.com/4543448/230634284-e7a50736-167e-4dba-9113-20467937c82b.jpg" width=450px>       |
 
 - Install [JELOS](https://github.com/JustEnoughLinuxOS/distribution)
 - In network-settings enable wifi & ssh
@@ -41,7 +43,11 @@ wget ZIP_URL -O r.zip
 unzip r.zip
 rm r.zip
 
+# For RG353P
 cp rm8-RG353P.json rm8.json
+
+# For RG353V
+cp rm8-RG353V.json rm8.json 
 
 # make it look like script below
 nano ../M8.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Update**: I have stopped working on this version, and recommend [m8c](https://github.com/laamaa/m8c). It's definitely more mature, and has more cool stuff implemented. They now have support for similar (hacky) audio-routing in SDL, which was the original purpose of this, for me (easier config of auto-routing.)
+
+
 # RM8
 
 Remote display for the [Dirtywave M8](https://dirtywave.com/)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ I first tried M8WebDisplay then discovered m8c and decided to use it as a starti
 
 # Config
 
+You can get device-specific tips in [DEVICES](https://github.com/konsumer/rm8/blob/master/DEVICES.md).
+
+
 [SDL scancodes](https://github.com/libsdl-org/SDL/blob/main/include/SDL_scancode.h)
 
 [SDL keycodes](https://github.com/libsdl-org/SDL/blob/main/include/SDL_keycode.h)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can get device-specific tips in [DEVICES](https://github.com/konsumer/rm8/bl
 
 `Alt + Shift + R key` will do a full reset of the display (disconnect + enable and reset display)
 
-`Alt + C` will enter config mode.
+`Alt + C` will enter config mode. THink of this as "extreme dev secret everything-broke menu". Many options will crash rm8.
 
 `Escape` will either quit the application or fullscreen mode or config mode or key remapping mode.
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ You can get device-specific tips in [DEVICES](https://github.com/konsumer/rm8/bl
     SHIFT     = LSHIFT       # M8's `SHIFT` key
     PLAY      = SPACE        # M8's `PLAY` key
 
-    EDIT      = LCTRL        # M8's `EDIT` key
-    OPTION    = LALT         # M8's `OPTION` key
+    EDIT      = Z            # M8's `EDIT` key
+    OPTION    = X            # M8's `OPTION` key
 
     KEYJAZZ   = RETURN       # Enter keyjazz mode
     OCTAVE+   = RIGHTBRACKET # Increment octave

--- a/rm8-RG353P.json
+++ b/rm8-RG353P.json
@@ -1,0 +1,117 @@
+{
+  "app": {
+    "fullscreen": false,
+    "font": "Uppercase",
+    "zoom": 4,
+    "key_sensibility": 60,
+    "fps": 60,
+    "show_fps": false,
+    "reconnect": false
+  },
+  "theme": {
+    "screen": "#000000",
+    "text_default": "#8c8cba",
+    "text_value": "#fafafa",
+    "text_title": "#32ecff",
+    "text_info": "#60608e",
+    "cursor": "#32ecff",
+    "octave_bg": "#0000ff",
+    "octave_fg": "#ffffff",
+    "velocity_bg": "#ff0000",
+    "velocity_fg": "#ffffff"
+  },
+  "m8": {
+    "up": "Up",
+    "down": "Down",
+    "left": "Left",
+    "right": "Right",
+    "edit": "Left Ctrl",
+    "option": "Left Alt",
+    "shift": "Left Shift",
+    "play": "Space"
+  },
+  "rm8": {
+    "keyjazz": "Return",
+    "velocity_minus": "-",
+    "velocity_plus": "=",
+    "octave_minus": "[",
+    "octave_plus": "]"
+  },
+  "joysticks": {
+    "190000004b4800000111000000010000": {
+      "buttons": {
+        "15": "Left",
+        "16": "Right",
+        "8": "Escape",
+        "14": "Down",
+        "0": "Option",
+        "1": "Edit",
+        "2": "Play",
+        "17": "Escape",
+        "3": "Shift",
+        "13": "Up",
+        "9": "Config"
+      },
+      "axes": {
+        "4": {
+          "sensibility": 20000
+        },
+        "5": {
+          "sensibility": 20000
+        },
+        "3": {
+          "sensibility": 20000
+        },
+        "2": {
+          "sensibility": 20000
+        },
+        "0": {
+          "negative": "Left",
+          "positive": "Right",
+          "sensibility": 20000
+        },
+        "1": {
+          "negative": "Up",
+          "positive": "Down",
+          "sensibility": 20000
+        }
+      }
+    }
+  },
+  "keyjazz": {
+    "Q": 12,
+    "U": 23,
+    "9": 25,
+    "X": 2,
+    "O": 26,
+    "V": 5,
+    "Z": 0,
+    "7": 22,
+    "0": 27,
+    ";": 15,
+    "C": 4,
+    "/": 16,
+    "J": 10,
+    "W": 14,
+    "6": 20,
+    "S": 1,
+    "D": 3,
+    "2": 13,
+    "P": 28,
+    "3": 15,
+    "H": 8,
+    "I": 24,
+    ",": 12,
+    "E": 16,
+    "G": 6,
+    "N": 9,
+    "B": 7,
+    "L": 13,
+    "R": 17,
+    "Y": 21,
+    "M": 11,
+    "5": 18,
+    "T": 19,
+    ".": 14
+  }
+}

--- a/rm8-RG353V.json
+++ b/rm8-RG353V.json
@@ -1,0 +1,117 @@
+{
+  "app": {
+    "fullscreen": false,
+    "font": "Uppercase",
+    "zoom": 4,
+    "key_sensibility": 60,
+    "fps": 60,
+    "show_fps": false,
+    "reconnect": false
+  },
+  "theme": {
+    "screen": "#000000",
+    "text_default": "#8c8cba",
+    "text_value": "#fafafa",
+    "text_title": "#32ecff",
+    "text_info": "#60608e",
+    "cursor": "#32ecff",
+    "octave_bg": "#0000ff",
+    "octave_fg": "#ffffff",
+    "velocity_bg": "#ff0000",
+    "velocity_fg": "#ffffff"
+  },
+  "m8": {
+    "up": "Up",
+    "down": "Down",
+    "left": "Left",
+    "right": "Right",
+    "edit": "Left Ctrl",
+    "option": "Left Alt",
+    "shift": "Left Shift",
+    "play": "Space"
+  },
+  "rm8": {
+    "keyjazz": "Return",
+    "velocity_minus": "-",
+    "velocity_plus": "=",
+    "octave_minus": "[",
+    "octave_plus": "]"
+  },
+  "joysticks": {
+    "19009b4d4b4800000111000000010000": {
+      "buttons": {
+        "15": "Left",
+        "16": "Right",
+        "8": "Escape",
+        "14": "Down",
+        "0": "Option",
+        "1": "Edit",
+        "2": "Play",
+        "17": "Escape",
+        "3": "Shift",
+        "13": "Up",
+        "9": "Config"
+      },
+      "axes": {
+        "4": {
+          "sensibility": 20000
+        },
+        "5": {
+          "sensibility": 20000
+        },
+        "3": {
+          "sensibility": 20000
+        },
+        "2": {
+          "sensibility": 20000
+        },
+        "0": {
+          "negative": "Left",
+          "positive": "Right",
+          "sensibility": 20000
+        },
+        "1": {
+          "negative": "Up",
+          "positive": "Down",
+          "sensibility": 20000
+        }
+      }
+    }
+  },
+  "keyjazz": {
+    "Q": 12,
+    "U": 23,
+    "9": 25,
+    "X": 2,
+    "O": 26,
+    "V": 5,
+    "Z": 0,
+    "7": 22,
+    "0": 27,
+    ";": 15,
+    "C": 4,
+    "/": 16,
+    "J": 10,
+    "W": 14,
+    "6": 20,
+    "S": 1,
+    "D": 3,
+    "2": 13,
+    "P": 28,
+    "3": 15,
+    "H": 8,
+    "I": 24,
+    ",": 12,
+    "E": 16,
+    "G": 6,
+    "N": 9,
+    "B": 7,
+    "L": 13,
+    "R": 17,
+    "Y": 21,
+    "M": 11,
+    "5": 18,
+    "T": 19,
+    ".": 14
+  }
+}

--- a/rm8.json
+++ b/rm8.json
@@ -24,8 +24,8 @@
     "down": "Down",
     "left": "Left",
     "right": "Right",
-    "edit": "Left Ctrl",
-    "option": "Left Alt",
+    "edit": "Z",
+    "option": "X",
     "shift": "Left Shift",
     "play": "Space"
   },

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# exit when any command fails
+set -e
+
+apt update
+apt install -y libsdl2-dev libudev-dev cargo zip
+
+cargo build --release
+cp target/release/rm8 .
+zip -r "${1}" rm8 *.json README.md

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -65,8 +65,7 @@ impl Audio {
 		} else {
 			for i in 0..audio.num_audio_capture_devices().unwrap_or(0) {
 				if let Ok(device_name) = audio.audio_capture_device_name(i) {
-					// println!("Found: {}", device_name);
-					if device_name.starts_with("M8") {
+					if device_name.contains("M8") {
 						return Self::real_open(audio, device_name, samples);
 					}
 				}

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -65,7 +65,8 @@ impl Audio {
 		} else {
 			for i in 0..audio.num_audio_capture_devices().unwrap_or(0) {
 				if let Ok(device_name) = audio.audio_capture_device_name(i) {
-					if device_name.starts_with("M8 Analog Stereo") {
+					// println!("Found: {}", device_name);
+					if device_name.starts_with("M8") {
 						return Self::real_open(audio, device_name, samples);
 					}
 				}

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,8 +86,8 @@ impl Default for M8KeyboardConfig {
 			down: SdlKeycode::Down.into(),
 			left: SdlKeycode::Left.into(),
 			right: SdlKeycode::Right.into(),
-			edit: SdlKeycode::LCtrl.into(),
-			option: SdlKeycode::LAlt.into(),
+			edit: SdlKeycode::Z.into(),
+			option: SdlKeycode::X.into(),
 			shift: SdlKeycode::LShift.into(),
 			play: SdlKeycode::Space.into(),
 		}


### PR DESCRIPTION
This will build several pre-compiled releases in Github CI (#6)

The idea is that it's triggered with a semver git-tag (like `v0.0.1`) but we can set it up some other way, if this is not convenient. For testing, I used dummy tags like `vtest24`. If you don't want to use semver, I think any tag could also trigger it, with a small change (so you can just tag your releases and it will generate a release for it.)

- [Here](https://github.com/konsumer/rm8/actions/runs/3784311140) is an example build
- [Here](https://github.com/konsumer/rm8/releases/tag/vtest24) is what that looks like, as a release.

Currently, it can build:

- linux (x86-64, arm64, arm32)
- mac (x86-64)
- windows (x86-64)

It will add a new tagged release with assets so users can download the built runtime for their platform (including some config examples and the README.)

This should have pi and handheld Anberinic devices (like [this](https://anbernic.com/products/rg35xx)) covered, as well as windows, and older macs. I need to do more testing. I have a Mac M1, and an Intel-mac, and a few different platforms for linux, so I will try to get those all verified (and windows, in a vmachine.)

Linux cross-building is very slow, since it builds in qemu. I think we could improve this using rust's cross-building stuff, but it seems a bit tricky with SDL2/libudev native deps.

Main build-things left to do is mac arm64 (for M1/M2 apple silicone) and I can't seem to get it, but I made an issue over [here](https://github.com/Rust-SDL2/rust-sdl2/issues/1279) asking for help. There is also currently an error trying to cross-build on linux `spurious network error - Value too large for defined data type; class=Os (2)` which I need to look into. It just started doing this, so maybe I need to adjust something in the docker-build.

I think for mac/linux, users will probly also need instructions for installing SDL, since it's dynamically-linked. For windows, I include a SDL2.dll in build.


```
# mac
brew install sdl2

# ubuntu/debian/etc
sudo apt update
sudo apt install libsdl2 libudev

# fedora/etc
sudo dnf install SDL2

# arch linux
sudo pacman -S sdl2
```
